### PR TITLE
src/quickstart.md: fix package installation command for Arch Linux

### DIFF
--- a/src/quickstart.md
+++ b/src/quickstart.md
@@ -10,7 +10,7 @@ Here are examples for `Arch Linux`, `Debian`, `Fedora`, `OpenAnolis` and
 
 ```sh
 # Arch Linux
-$ sudo pacman -Sy erofs-utils
+$ sudo pacman -S erofs-utils
 
 # Debian and Ubuntu
 $ sudo apt install -y erofs-utils

--- a/src/roadmap.md
+++ b/src/roadmap.md
@@ -2,13 +2,20 @@
 
 ## Linux Kernel
 
- - [Sub-page block size support of compressed files](https://git.kernel.org/torvalds/c/0ee3a0d59e00);
+ - [Compressed data support over fscache](https://lore.kernel.org/r/20240308094159.40547-1-jefflexu@linux.alibaba.com);
 
- - [Support fscache daemon failover mechanism to recover from crashing](https://git.kernel.org/torvalds/c/26458409a9b1).
+ - Enable Large folio support for compressed data [\[1\]](https://lore.kernel.org/r/20240305091448.1384242-1-hsiangkao@linux.alibaba.com);
+
+ - Intel QAT/IAA accelerator support;
+
+ - Zstandard decompressor support;
+
+ - [Preliminary EROFS Rust in-kernel adaption (EXPERIMENTAL, program for students)](https://summer-ospp.ac.cn/org/prodetail/241920019).
 
 ## Userspace tools (erofs-utils)
 
- - Multi-threaded (de)compression;
+ - Multi-threaded (de)compression [\[1\]](https://lore.kernel.org/r/20240228161652.1010997-1-zhaoyifan@sjtu.edu.cn)
+[\[2\]](https://lore.kernel.org/r/20240422003450.19132-1-xiang@kernel.org);
 
  - Intel QAT/IAA accelerator support;
 


### PR DESCRIPTION
Installing a package using `pacman -Sy` can cause a partial update. See https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported