### PR TITLE
docs: fix grammar, update metadata compression info, and correct LZMA version

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -3,7 +3,7 @@
 # -- Project information
 
 project = 'EROFS'
-copyright = '2018-2025, EROFS filesystem developers'
+copyright = '2018-2026, EROFS filesystem developers'
 author = 'EROFS filesystem developers'
 
 version = '0.1'

--- a/src/design.md
+++ b/src/design.md
@@ -40,7 +40,7 @@ The main benefits of using fixed-size blocks are:
    encoded blocks could still be _cached in the page cache for later use_.
    This is quite useful on memory-limited devices since _caching compressed data
    is generally more efficient than decompressed data if selected compression
-   algorithms is **fast** enough_ (considering main benefits of ZSWAP or ZRAM).
+   algorithms are **fast** enough_ (considering main benefits of ZSWAP or ZRAM).
    Although unaligned solutions could also cache encoded data in page cache,
    reclaiming could lead to lower cache pages utilization due to fragmentation
    since page cache reclaims data in pages instead of bytes.
@@ -63,7 +63,7 @@ block utilization and maximize compression ratios.
 
 Such compression approach is not required. However, without this approach,
 the final blocks of physical clusters will not be fully filled with encoded
-data. Currently LZ4, LZMA (Linux 5.15+), DEFLATE (Linux 6.6+), and Zstandard
+data. Currently LZ4, LZMA (Linux 5.16+), DEFLATE (Linux 6.6+), and Zstandard
 (Linux 6.10+) algorithms natively support this mode.
 
 Fixed-size output compression generally provides better compression ratios,

--- a/src/developers.md
+++ b/src/developers.md
@@ -46,7 +46,7 @@ When posting, it is helpful to:
  - Avoid [top-posting](https://daringfireball.net/2007/07/on_top) if possible.
 
 All patches should follow the Linux kernel's coding style. Additionally, as
-one of Linux kernel development communities, patches require the "sign-off"
+one of the Linux kernel development communities, patches require the "sign-off"
 procedure.
 
 The sign-off should be appended as a simple line at the end of the commit

--- a/src/faq.md
+++ b/src/faq.md
@@ -45,11 +45,11 @@ In addition, EROFS may produce larger images due to the following differences:
    for regular files; Consider switching to 32-byte EROFS compact inodes (e.g.,
    by using `-T`) if per-file timestamps are not a strong requirement;
 
- - **Lack of metadata compression**: If your test sets contain a large number of
-   files, EROFS may result in larger images compared to SquashFS because of
-   metadata compression is not supported. Again, it isn't considered at first
-   due to bad impacts to random metadata performance but it may be implemented
-   in the future.
+ - **Metadata compression**: If your test sets contain a large number of
+   files, EROFS may result in larger images compared to SquashFS if
+   metadata compression is not enabled. Optional metadata compression has been
+   supported since Linux 6.17; consider enabling it if metadata size is a
+   concern.
 
  - **File-based deduplication**: SquashFS deduplicates files with identical data
    by default (it can be disabled with `-no-duplicates`), whereas EROFS does not
@@ -62,7 +62,7 @@ In addition, EROFS may produce larger images due to the following differences:
 
 Note that EROFS is still under active development. The features mentioned above
 are not top priorities at the moment due to limited development resources
-(anyway, SquashFS has been existed for over 20 years) and target use scenarios,
+(anyway, SquashFS has existed for over 20 years) and target use scenarios,
 but they will be considered in the future, and contributions are always welcome.
 Again, note that SquashFS doesn't always outperform EROFS in image size either.
 EROFS images are often significantly smaller (while still offering better

--- a/src/features.md
+++ b/src/features.md
@@ -69,7 +69,7 @@ optional metadata compression has been supported since Linux 6.17 to minimize
 filesystem images.
 
 [^9]: Strictly speaking, EXT4 has a feature named "[shared_blocks](https://lore.kernel.org/r/20201005161941.GF4225@quack2.suse.cz)",
-which will prevents applications from writing to the filesystem.
+which will prevent applications from writing to the filesystem.
 
 [^10]: For example, `direct I/O` can be used for loop devices backed by
 unencoded files on the EROFS filesystem to avoid double caching. `Direct I/O`

--- a/src/install.md
+++ b/src/install.md
@@ -55,7 +55,7 @@ $ git clone git://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git
 The repo defaults to the master development branch. You can also check out a release tag to build:
 
 ```sh
-$ git checkout <tag> # v1.8.10, v1.7.1, v1.6, etc.
+$ git checkout <tag> # v1.9.1, v1.8.10, v1.7.1, etc.
 ```
 
 ### Configure and build

--- a/src/merging.md
+++ b/src/merging.md
@@ -44,7 +44,7 @@ Besides, it is quite useful for scenarios where we have no way to compose
 a single specific block device from individual sources as described in the
 previous section.
 
-In addition, Since [Linux 5.19](https://lwn.net/Articles/896140), EROFS has
+In addition, since [Linux 5.19](https://lwn.net/Articles/896140), EROFS has
 added __EROFS over fscache__ to make use of fscache caching framework without
 explicit block devices, which is currently used by
 [Dragonfly Nydus image service](https://nydus.dev). There are some benefits

--- a/src/mkfs.md
+++ b/src/mkfs.md
@@ -48,8 +48,10 @@ $ mkfs.erofs -zlz4hc,12 -C65536 -Efragments,ztailpacking foo.erofs foo/
 
 By default, EROFS just uses a physical cluster size equal to the block size
 (e.g., 4096 on x86) and disables advanced features to keep the random access
-performance. Consider increasing `-C` and enabling advanced features if
-a smaller image size is desired.
+performance. Consider increasing `-C` (e.g., to 65536 or 131072) and enabling
+advanced features if a smaller image size is desired. Note that larger cluster
+sizes may increase memory footprint during decompression and degrade random
+access performance.
 
 Using `-Eall-fragments` is not recommended now, as it can degrade runtime
 performance unless minimizing image size is the top priority. `-Efragments`
@@ -77,7 +79,7 @@ Here are some frequently used additional options for `mkfs.erofs` tar mode:
 | --sort=none | (only valid with `--tar=f`) Keep inode data order consistent with tar data order.            |
 | --sort=path | (only valid with `--tar=f`) Data order strictly follows the tree generation order (default). |
 
-For example, to generate an full EROFS image from a tarball `foo.tar`:
+For example, to generate a full EROFS image from a tarball `foo.tar`:
 
 ```sh
 $ mkfs.erofs --tar=f --sort=none foo.erofs foo.tar


### PR DESCRIPTION
This PR includes several small fixes to improve document readability and accuracy:

1. Updated outdated information: Corrected the "Lack of metadata compression" section in [faq.md](cci:7://file:///d:/docs/src/faq.md:0:0-0:0) (metadata compression has been supported since Linux 6.17) and fixed the MicroLZMA kernel version in [design.md](cci:7://file:///d:/docs/src/design.md:0:0-0:0) to align with [features.md](cci:7://file:///d:/docs/src/features.md:0:0-0:0). 

2. General cleanup: Fixed various grammatical errors (subject-verb agreement, verb conjugation, articles, capitalization) across multiple files.

3. Minor updates: Bumped the copyright year to 2026 in [conf.py](cci:7://file:///d:/docs/src/conf.py:0:0-0:0) and added the latest `v1.9.1` release tag to the `git checkout` example in `install.md`.
