### PR TITLE
docs: improve clarity in xattrs and chunked format documentation

### DIFF
--- a/src/ondisk/chunked_format.md
+++ b/src/ondisk/chunked_format.md
@@ -49,7 +49,7 @@ inode offset 0x10) is interpreted as a chunk info summary:
 
 | Bits  | Width | Description |
 |-------|-------|-------------|
-| 0–4   | 5     | `chunkbits`: chunk size = `2^(blkszbits + chunkbits)` |
+| 0–4   | 5     | `chunkbits`: chunk size = 2 to the power of (`blkszbits + chunkbits`) |
 | 5     | 1     | `EROFS_CHUNK_FORMAT_INDEXES`: entry format selector (see below) |
 | 6     | 1     | 48-bit layout specific; ignored for basic chunk-based inodes |
 | 7–31  | 25    | Reserved; must be 0 |

--- a/src/ondisk/xattrs.md
+++ b/src/ondisk/xattrs.md
@@ -125,7 +125,8 @@ When clear, the full byte selects one of the built-in short namespace prefixes:
 | 4     | `trusted.` |
 | 6     | `security.` |
 
-All other `e_name_index` values (including `0` and `5`) are reserved and must not be used unless defined by a future format extension.
+`e_name_index` value `0` is used for arbitrary namespace xattrs and may be hidden at runtime.
+Other values (such as `5`) are currently reserved unless defined by future format extensions.
 (shared_xattr_area)=
 ## Shared Xattr Area
 

--- a/src/ondisk/xattrs.md
+++ b/src/ondisk/xattrs.md
@@ -125,6 +125,7 @@ When clear, the full byte selects one of the built-in short namespace prefixes:
 | 4     | `trusted.` |
 | 6     | `security.` |
 
+All other `e_name_index` values (including `0` and `5`) are reserved and must not be used unless defined by a future format extension.
 (shared_xattr_area)=
 ## Shared Xattr Area
 
@@ -144,8 +145,8 @@ This section applies when `EROFS_FEATURE_INCOMPAT_XATTR_PREFIXES` is set.
 
 When this feature is set, a table of `xattr_prefix_count` prefix entries is
 present; see {ref}`xattr_prefix_table_placement` for where that table is stored.
-Each entry has the following fixed header, padded together with the
-variable-length `infix` payload to a 4-byte boundary:
+Each entry has the following fixed header. The full entry, including the
+variable-length `infix` payload, is padded to a 4-byte boundary.
 
 | Offset | Size | Type  | Name         | Description |
 |--------|------|-------|--------------|-------------|


### PR DESCRIPTION
This PR improves clarity in xattr and chunk-based format documentation.

Changes:
- Added note about reserved e_name_index values (0 and 5)
- Standardized "Bloom filter" capitalization
- Improved wording for long xattr prefix structure
- Clarified chunk size formula expression to avoid ambiguity

These changes are based on discussion in #28.